### PR TITLE
Small bug fix regarding optional parameters in route

### DIFF
--- a/route-parser/route-parser.js
+++ b/route-parser/route-parser.js
@@ -45,7 +45,7 @@ module.exports = function(RED) {
             }
 
             var outMsg = {};
-            var keys = msg.req.route.path.split("/");
+            var keys = msg.req.route.path.replace('?','').split("/");
             var words = msg.req.path.split("/");
             for (var i = 0; i < keys.length; i++) {
                 if (keys[i].lastIndexOf(":", 0) === 0) {


### PR DESCRIPTION
If a route was defined with optional parameters like `/:foo/:bar?` and it was called like `/route/param` the output of this node was like

`{"foo":"route", "bar?": "param"}`

This fix strips all  `?` characters from the route before it is tokenized.